### PR TITLE
psyco: drop it, it is unsupported

### DIFF
--- a/amagama/benchmark.py
+++ b/amagama/benchmark.py
@@ -56,12 +56,6 @@ class BenchmarkTMDB(Command):
         self.max_candidates = max_candidates and int(max_candidates)
 
         try:
-            import psyco
-            psyco.full()
-        except Exception:
-            pass
-
-        try:
             if not filename:
                 print >> sys.stderr, "Please specify a file or directory to use."
             elif not os.path.exists(filename):

--- a/bin/amagama
+++ b/bin/amagama
@@ -41,12 +41,6 @@ def main():
     level = options.debug and logging.DEBUG or logging.WARNING
     if options.debug:
         format = '%(levelname)7s %(module)s.%(funcName)s:%(lineno)d: %(message)s'
-    else:
-        try:
-            import psyco
-            psyco.full()
-        except Exception:
-            pass
 
     logging.basicConfig(level=level, format=format)
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,7 +42,6 @@ It also has some optional dependencies:
 - For better performance:
 
   - **python-Levenshtein**
-  - **psyco** (if available for your platform)
 
 
 .. _installation#installation:

--- a/min-required.txt
+++ b/min-required.txt
@@ -5,5 +5,4 @@ translate-toolkit==1.8.0
 python-Levenshtein==0.10.2
 Flask-Script==0.3
 Flask-WTF==0.5.2
-#psyco==1.6
 Sphinx==1.1

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,8 +1,3 @@
 -r recommended.txt
 
 Flask-WTF>=0.5.2
-
-# Note: psyco is dead; final release 1.6 does not support 64-bit or Python 2.7
-# You may still get a speedup on 32-bit architecture with Python 2.6
-# (if you can find a PyPI server that still has psyco at all)
-#psyco>=1.6


### PR DESCRIPTION
While it might work on Python 2.6, most people won't be running on that
anyway and we won't be for amagama.locamotion.org

So remove it so we don't need to maintain it.
