### PR TITLE
Bug workaround to keep amaGama server alive

### DIFF
--- a/amagama/postgres.py
+++ b/amagama/postgres.py
@@ -22,7 +22,7 @@
 
 import psycopg2.extensions
 from flask import g, got_request_exception
-from psycopg2 import IntegrityError
+from psycopg2 import IntegrityError, ProgrammingError
 from psycopg2.extras import DictCursor
 from psycopg2.pool import PersistentConnectionPool
 


### PR DESCRIPTION
When querying for strings like '<a "\b">' (being single quotes and double
quotes part of the string itself) we get a

ProgrammingError: syntax error in tsquery

exception. It is pretty uncommon to query for strings like this, but when
it happens we have the amaGama server down, sometimes for days.
